### PR TITLE
Add template-making scripts to prepare a VM as templates

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,31 @@
+# Justfile for SaltStack
+# ======================
+# This Justfile contains some recipes useful for the Ryhino project's Salt Stack. These recipes can be
+# executed by "casey/just".
+
+
+[private]
+default:
+    just --list
+
+
+# Template Makers
+# ===============
+# Prepare a VM to be cloned as templates.
+
+# Prevent SSH from checking if the host is known and writing the host to known host.
+SSH_NO_CHECK_HOST := "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+# Directory containing all the template-making scripts
+TEMPLATE_DIR := "scripts/template-makers"
+
+# Command that write the template-making script to the dest. Used by `prepare-remote-as-template`.
+WRITE_TEMPLATE_CMD := "cat > prepare-as-template.sh; chmod 777 prepare-as-template.sh"
+
+
+[private]
+prepare-remote-as-template template dest:
+    op inject -i {{ TEMPLATE_DIR }}/{{ template }}.sh.tmpl | {{ SSH_NO_CHECK_HOST }} {{ dest }} "{{ WRITE_TEMPLATE_CMD }}"
+
+# Prepare {{dest}} VM to be used as a generic Rocky Linux template. {{dest}} looks like "rocky@10.0.0.1".
+prepare-generic-rocky-template dest: (prepare-remote-as-template "generic-rocky" dest)

--- a/scripts/template-makers/generic-rocky.sh.tmpl
+++ b/scripts/template-makers/generic-rocky.sh.tmpl
@@ -1,0 +1,33 @@
+#! /usr/bin/env bash
+#
+# This script is used to prepare a freshly-instealled Rocky Linux 9 VM to a "generic"
+# one that can be cloned into a template.
+#
+# Note that this is only a template that needs to be injected by `op` (1Password CLI 2).
+# See the `justfile` at project root for recipes to do so.
+
+set -euxo pipefail
+
+dnf upgrade --assumeyes
+
+# SaltStack needs guest customization, which depends on `open-vm-tools`, which
+# implicitly depends on `perl` even thought it doesn't pull it in when
+# installed. Otherwise, when `salt-cloud` deploys a VM, the NIC stays
+# "disconnected" in vCenter even though it was created.
+dnf install open-vm-tools perl vim --assumeyes
+
+echo "Writing SSH key for root..."
+mkdir -p /root/.ssh
+cat >/root/.ssh/authorized_keys <<EOF
+{{ op://ryhino/3go34rott677qsgub7vj5md4fi/public_key }}
+EOF
+chmod 700 /root/.ssh
+chmod 600 /root/.ssh/authorized_keys
+
+echo "Allowing only key-based logins..."
+sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config
+
+dnf clean all
+
+echo "We are done. Deleting this script itself..."
+rm -- "$0"


### PR DESCRIPTION
Add a very simple script that prepares a remote VM so it can be used as a template. This is to prepare for salt-cloud template-based provisioning.

Also added a `Justfile` that can be used to inject private SSH key and upload the script to the remote.