### PR TITLE
Add support for using `salt-cloud` to deploy VMs on Ryhino

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,3 +29,13 @@ prepare-remote-as-template template dest:
 
 # Prepare {{dest}} VM to be used as a generic Rocky Linux template. {{dest}} looks like "rocky@10.0.0.1".
 prepare-generic-rocky-template dest: (prepare-remote-as-template "generic-rocky" dest)
+
+
+# GPG
+# =====
+# Encrypt Salt pillar data with GPG
+
+GPG_KEY_FINGERPRINT := "5C5A7608E659DB56C168ABC03C4BF56A3043568B"
+
+encrypt-pillar:
+    gpg --armor --trust-model always -r {{ GPG_KEY_FINGERPRINT }} --encrypt

--- a/pillar/saltmaster/init.sls
+++ b/pillar/saltmaster/init.sls
@@ -1,0 +1,23 @@
+salt_cloud:
+  providers:
+    vcenter_bedrock:
+      user: |
+        -----BEGIN PGP MESSAGE-----
+        hF4DNtygortYQDMSAQdAefuMh1f3ixayvIzJOVFoh5Z29mBkC/OD+ViU0Uq9Ki4w
+        8WnbTy9PIXChcspUkTniv+2aZnAPbreEq41CMhr3GxcwUfBvO5YL7joAmzWTDmOx
+        1JQBCQIQ2Akwtvgeh+S9t7cDNO8eRDRBnHSqqNPxWVN3yWO6yBQgn4m4PtFng1Bb
+        ZXROyZnFWxcVDiAOu3KkIXnS5JYOoldERc3nfUhuBs2OUSabLngVlZ6AZ0PHfkV/
+        pbnTnWr22Nb2NUYNNKyfRyJsg+iCYfDwAwWA7rKvv9wbHcs5S3PiKFziMVVOB/C+
+        N6dhoI2O
+        =zaUv
+        -----END PGP MESSAGE-----
+
+      password: |
+        -----BEGIN PGP MESSAGE-----
+        hF4DNtygortYQDMSAQdAi5jyiLRkgAdRbNW2UKZbfYOALayhB85/mD5XtI0091sw
+        MBqRyCLDvE31wrTn/WBbvx84s6pOK+Hc6V0S0EZtIHCknCisKGfD4+O7GBkftSHk
+        1IcBCQIQRhQTBhybwDxcaLv6JO6cJRmXrHcWIUT9AkZOUPoSe8bP+wU91rJGSw7J
+        rThNZ2oDfbOO6F8+LFoQ3dS7cAhtP4C8qOoLZKOaQhfzHQDL9BYBAxG55nlIEJF8
+        m7clGra1HGja+4JdRr0GZCp703/fcx4BvV8FRzPCFCCgI++ctJIJXZg=
+        =fIVW
+        -----END PGP MESSAGE-----

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,0 +1,3 @@
+base:
+  'salt.*':
+    - saltmaster

--- a/salt/salt/cloud.sls
+++ b/salt/salt/cloud.sls
@@ -1,0 +1,55 @@
+# `salt-cloud`-related states
+# ===========================
+# These states should result in a usable `salt-cloud` for deploying under Ryhino.
+{% import_yaml "salt/initial_keys.map" as initial_keys %}
+
+
+/etc/salt/cloud:
+  file.managed:
+    - source: salt://salt/files/cloud
+    - user: saltmaster
+    - group: saltmaster
+    - mode: 644
+    - makedirs: True
+
+
+/etc/salt/cloud.profiles.d:
+  file.recurse:
+    - source: salt://salt/files/cloud.profiles.d
+    - user: saltmaster
+    - group: saltmaster
+    - dir_mode: 755
+    - file_mode: 644
+    - template: jinja
+
+
+/etc/salt/cloud.providers.d:
+  file.recurse:
+    - source: salt://salt/files/cloud.providers.d
+    - user: saltmaster
+    - group: saltmaster
+    - dir_mode: 755
+    - file_mode: 644
+    - template: jinja
+
+# Keys to log into VMs deployed by `salt-cloud` after they get cloned/created
+# initially.
+# Each VM template will have a different SSH key that can be used to log into
+# `root`, which is to facilitate Salt doing some initial bootstrapping.
+/etc/salt/cloud.initial-keys.d:
+  file.directory:
+    - user: saltmaster
+    - group: saltmaster
+    - dir_mode: 755
+    - file_mode: 644
+
+
+# These keys will be copied to all salt masters and are defined under "initial_keys.map".
+{% for key_name in initial_keys %}
+/etc/salt/cloud.initial-keys.d/{{ key_name }}:
+  file.managed:
+    - user: saltmaster
+    - group: saltmaster
+    - mode: 600
+    - contents: {{ initial_keys[key_name] | yaml_encode }}
+{% endfor %}

--- a/salt/salt/files/cloud
+++ b/salt/salt/files/cloud
@@ -1,0 +1,5 @@
+# salt-cloud Global Configuration
+# This file should normally be installed at: /etc/salt/cloud
+
+minion:
+  master: salt.bedrock.ryanl.io

--- a/salt/salt/files/cloud.profiles.d/infra-rocky-obsidian.conf
+++ b/salt/salt/files/cloud.profiles.d/infra-rocky-obsidian.conf
@@ -1,0 +1,45 @@
+# VM that should be suitable for most infrastructure-related usages, directly located on Obsidian.
+# Specs:
+#   - CPUs: 2
+#   - Memory: 4GB
+#   - Hard Disk: 16GB (Thin)
+
+infra-rocky-obsidian:
+  template: False
+  clonefrom: generic-rocky-9.1
+  provider: vcenter-bedrock
+
+  num_cpus: 4
+  memory: 4GB
+  devices:
+    disk:
+      Hard disk 1:
+        size: 16
+        controller: SCSI controller 1
+        thin_provision: true
+        eagerly_scrub: false
+        datastore: obsidian-bucket
+
+    scsi:
+      SCSI controller 1:
+        type: paravirtual
+
+    network:
+      Network adapter 1:
+        name: obsidian-spg-infra
+        switch_type: standard
+
+  ssh_username: root
+  private_key: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
+
+  datacenter: bos1
+  host: obsidian.bedrock.ryanl.io
+  resourcepool: infra
+
+  power_on: True
+  deploy: True
+  customization: True
+  minion:
+    master: salt.bedrock.ryanl.io
+
+  annotation: Created by Salt-Cloud

--- a/salt/salt/files/cloud.providers.d/vcenter-bedrock.conf
+++ b/salt/salt/files/cloud.providers.d/vcenter-bedrock.conf
@@ -1,0 +1,13 @@
+# Provider info for the vCenter, which manages all physical servers in Ryhino.
+# This file should normally be installed at: /etc/salt/cloud.providers.d/
+#
+{% set vcenter_bedrock = salt['pillar.get']("salt_cloud:providers:vcenter_bedrock") %}
+
+vcenter-bedrock:
+  driver: vmware
+  user: {{ vcenter_bedrock.user }}
+  password: {{ vcenter_bedrock.password }}
+  url: vcenter.bedrock.ryanl.io
+  protocol: "https"
+  port: 443
+  verify_ssl: false

--- a/salt/salt/files/master
+++ b/salt/salt/files/master
@@ -1,0 +1,5 @@
+# salt-master Global Configuration
+# This file should normally be installed at: /etc/salt/master
+
+user: saltmaster
+renderer: jinja | yaml | gpg

--- a/salt/salt/initial_keys.map
+++ b/salt/salt/initial_keys.map
@@ -1,0 +1,22 @@
+# Initial Keys to Deployed Templates
+# ==================================
+# These keys can be used to log into VMs deployed by `salt-cloud` after they get
+# cloned/created initially.
+# Each VM template will have a different SSH key that can be used to log into `root`,
+# which is to facilitate Salt doing some initial bootstrapping.
+
+generic-rocky-9.1: |
+  -----BEGIN PGP MESSAGE-----
+  hF4DNtygortYQDMSAQdA9KYDjXrRj/cjejDy1fk1nNRK8qeDyvsDyu1ErzRLOT8w
+  7FKsIY8lolnZ/PM7iKG9pcPQGihT+Ur3WPxBWLnfHGHnCGQRNz/klS0n1VRf/8F/
+  1MDSAQkCEGW/HpsWC4zoNkZOCLapyyXU0XvR/bQVTrabd7/OcDhwY9KB6LSTu3Km
+  AA+m3mYaSw1a0msFAAsdCnrbECxA9UheAVThKSUdasziw4cL3yzHL2sduuIn0YL/
+  HKKguzaJONsq7juEnW+rYOPKjWnqqsTHX0CMm+HnZXry8c9vxDPAspqxx7pT5wdN
+  bKhcCIzww6NVAdths6/z3elaMIsj/gbS6r/uJGUc+w+TgdNfZH974zvBA70o5+yV
+  KVybqBK0HQEzFPLY/b+FWyKvf2yICMlhFk96dK8dT5szOeqc6vvrDU0KaZKWkYUF
+  h8qFkIIXsHiz5M7fOAOryok3DOm6UFc+OAv3a/CYpjVrXtGozi8KqWH6wjfEAh0w
+  LaukkwgqDpOIRWV7QT7PkQxZAgJ0/YlhNY/78IoJqneSKDPhLD3boxrrvMB8blqF
+  1JagFVn37v6te/ukoDFQLjhAgqRT3+J6wjnl+FpG+kqoDUm8RuZSewxU09hri54I
+  vayz5TOCwtdWT6gESS2jyv1vwYAi
+  =Hc7y
+  -----END PGP MESSAGE-----

--- a/salt/salt/master.sls
+++ b/salt/salt/master.sls
@@ -1,0 +1,11 @@
+# `salt-master`-related states
+# ===========================
+# These states should result in a usable Salt Master for deploying under Ryhino.
+
+/etc/salt/master:
+  file.managed:
+    - source: salt://salt/files/master
+    - user: saltmaster
+    - group: saltmaster
+    - mode: 644
+    - makedirs: True

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,5 +1,7 @@
 # Highstate for all Salt minions under Ryhino
 
 base:
-    'salt.*':
-        - os.auto-update
+  'salt.*':
+    - os.auto-update
+    - salt.master
+    - salt.cloud


### PR DESCRIPTION
This is still in its early stages. This commit mainly aims to lay down the foundation for future flush-outs.

States defined in this commit can be used to initialize a new salt master that can handle everything the prod can, i.e. the prod is now saltified.

This commit adds:
- Small amount of salt-master configuration
- Config to connect to the bedrock vCenter
- GPG-based secret rendering
- One template-based VM profile with Rocky Linux directly on Obsidian and infra VLAN.

## Logs
State with _some_ changes:
```
[saltmaster@salt srv]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 13:32:27.876073
    Duration: 188.573 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 13:32:28.096936
    Duration: 82.067 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 13:32:28.180387
    Duration: 45.973 ms
     Changes:
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 13:32:28.226948
    Duration: 41.771 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: Recursively updated /etc/salt/cloud.profiles.d
     Started: 13:32:28.269297
    Duration: 383.425 ms
     Changes:
              ----------
              /etc/salt/cloud.profiles.d/infra-rocky-obsidian.conf:
                  ----------
                  diff:
                      New file
                  group:
                      saltmaster
                  mode:
                      0644
                  user:
                      saltmaster
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 13:32:28.780901
    Duration: 238.982 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 13:32:29.020330
    Duration: 3.973 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 13:32:29.024739
    Duration: 7.723 ms
     Changes:

Summary for salt.bedrock.ryanl.io
------------
Succeeded: 8 (changed=1)
Failed:    0
------------
Total states run:     8
Total run time: 992.487 ms
```

Consecutive run, no state changes:
```
[saltmaster@salt srv]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 13:42:05.976596
    Duration: 199.877 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 13:42:06.208465
    Duration: 79.197 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 13:42:06.288863
    Duration: 50.214 ms
     Changes:
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 13:42:06.339645
    Duration: 39.346 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.profiles.d is in the correct state
     Started: 13:42:06.379558
    Duration: 91.815 ms
     Changes:
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 13:42:06.472015
    Duration: 109.601 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 13:42:06.582131
    Duration: 4.632 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 13:42:06.587217
    Duration: 8.91 ms
     Changes:

Summary for salt.bedrock.ryanl.io
------------
Succeeded: 8
Failed:    0
------------
Total states run:     8
Total run time: 583.592 ms
```