### PR TITLE
Open salt-master ports through `firewalld`

### DIFF
--- a/salt/salt/master.sls
+++ b/salt/salt/master.sls
@@ -9,3 +9,11 @@
     - group: saltmaster
     - mode: 644
     - makedirs: True
+
+
+# Open salt-master ports to public
+{% if grains['os'] == 'Rocky' %}
+public:
+  firewalld.present:
+    - services: salt-master
+{% endif %}


### PR DESCRIPTION
This commit opens up ports required by salt-master to communicate with minions through `firewalld`. Right now this only applies to Rocky Linux, since `firewalld` is mostly a RHEL thing.

## Logs
#### 1st Run
```
[saltmaster@salt srv]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 13:51:53.710168
    Duration: 189.474 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 13:51:53.932460
    Duration: 81.881 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 13:51:54.015559
    Duration: 50.136 ms
     Changes:
----------
          ID: public
    Function: firewalld.present
      Result: True
     Comment: 'public' was configured.
     Started: 13:51:54.089069
    Duration: 4963.248 ms
     Changes:
              ----------
              services:
                  ----------
                  new:
                      - cockpit
                      - ssh
                      - dhcpv6-client
                      - salt-master
                  old:
                      - cockpit
                      - dhcpv6-client
                      - ssh
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 13:51:59.053626
    Duration: 49.896 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.profiles.d is in the correct state
     Started: 13:51:59.104047
    Duration: 98.832 ms
     Changes:
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 13:51:59.203396
    Duration: 108.444 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 13:51:59.312360
    Duration: 4.748 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 13:51:59.317634
    Duration: 9.755 ms
     Changes:

Summary for salt.bedrock.ryanl.io
------------
Succeeded: 9 (changed=1)
Failed:    0
------------
Total states run:     9
Total run time:   5.556 s
```

#### 2rd Run
```
[saltmaster@salt srv]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 13:52:18.042142
    Duration: 191.69 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 13:52:18.265891
    Duration: 82.962 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 13:52:18.350075
    Duration: 48.263 ms
     Changes:
----------
          ID: public
    Function: firewalld.present
      Result: True
     Comment: 'public' is already in the desired state.
     Started: 13:52:18.422187
    Duration: 2644.173 ms
     Changes:
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 13:52:21.067638
    Duration: 55.36 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.profiles.d is in the correct state
     Started: 13:52:21.123551
    Duration: 87.26 ms
     Changes:
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 13:52:21.211296
    Duration: 239.556 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 13:52:21.451355
    Duration: 4.818 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 13:52:21.456675
    Duration: 9.448 ms
     Changes:

Summary for salt.bedrock.ryanl.io
------------
Succeeded: 9
Failed:    0
------------
Total states run:     9
Total run time:   3.364 s
```