### PR TITLE
Ensure `pyvmomi` is installed for `salt-cloud`

### DIFF
--- a/salt/salt/cloud.sls
+++ b/salt/salt/cloud.sls
@@ -4,6 +4,13 @@
 {% import_yaml "salt/initial_keys.map" as initial_keys %}
 
 
+# Install pyVmomi, which is needed to communicate with vCenter.
+# By default Salt should install it in an environment that Salt itself can use.
+pyvmomi:
+  pip.installed:
+    - upgrade: true
+
+
 /etc/salt/cloud:
   file.managed:
     - source: salt://salt/files/cloud


### PR DESCRIPTION
This commit adds a state that makes sure `pyvmomi` is installed, which is needed to communicate with vCenter. By default Salt should install it in an environment that Salt itself can use.

## Logs
#### 1st Run
```
[saltmaster@salt srv]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 14:18:12.474926
    Duration: 207.091 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 14:18:12.713414
    Duration: 80.009 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 14:18:12.794645
    Duration: 44.283 ms
     Changes:
----------
          ID: public
    Function: firewalld.present
      Result: True
     Comment: 'public' is already in the desired state.
     Started: 14:18:12.862008
    Duration: 2637.967 ms
     Changes:
----------
          ID: pyvmomi
    Function: pip.installed
      Result: True
     Comment: All packages were successfully installed
     Started: 14:18:19.330815
    Duration: 7407.038 ms
     Changes:
              ----------
              pyvmomi==8.0.0.1.2:
                  Installed
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 14:18:26.795186
    Duration: 78.175 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.profiles.d is in the correct state
     Started: 14:18:26.873696
    Duration: 43.576 ms
     Changes:
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 14:18:26.917533
    Duration: 86.161 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 14:18:27.004212
    Duration: 4.744 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 14:18:27.009414
    Duration: 9.349 ms
     Changes:

Summary for salt.bedrock.ryanl.io
-------------
Succeeded: 10 (changed=1)
Failed:     0
-------------
Total states run:     10
Total run time:   10.598 s
```

#### 2rd Run
```
[saltmaster@salt srv]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 14:21:20.387741
    Duration: 213.992 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 14:21:20.633011
    Duration: 81.093 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 14:21:20.715335
    Duration: 52.46 ms
     Changes:
----------
          ID: public
    Function: firewalld.present
      Result: True
     Comment: 'public' is already in the desired state.
     Started: 14:21:20.790748
    Duration: 2654.11 ms
     Changes:
----------
          ID: pyvmomi
    Function: pip.installed
      Result: True
     Comment: Python package pyvmomi was already installed
              All specified packages are already installed and up-to-date
     Started: 14:21:27.303042
    Duration: 4186.073 ms
     Changes:
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 14:21:31.489637
    Duration: 21.691 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.profiles.d is in the correct state
     Started: 14:21:31.511584
    Duration: 36.343 ms
     Changes:
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 14:21:31.548131
    Duration: 37.547 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 14:21:31.585881
    Duration: 1.763 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 14:21:31.587828
    Duration: 3.521 ms
     Changes:

Summary for salt.bedrock.ryanl.io
-------------
Succeeded: 10
Failed:     0
-------------
Total states run:     10
Total run time:    7.289 s
```