### PR TITLE
Add GitFS; Add Chrony-based NTP sync to pfSense

### DIFF
--- a/pillar/chrony/init.sls
+++ b/pillar/chrony/init.sls
@@ -1,0 +1,12 @@
+# Chrony
+# ======
+# Config Chrony so that it uses Ryhino's internal NTP server.
+# This relies on github.com/saltstack-formulas/chrony-formula
+
+
+chrony:
+  ntpservers:
+    # In Ryhino, the intranet NTP server is provided conveniently by pfSense.
+    # This address should be resolved automaically by pfSesne to itself no
+    # matter the subnet.
+    - "pfsense.bedrock.ryanl.io"

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,3 +1,6 @@
 base:
+  '*':
+    - chrony
+
   'salt.*':
     - saltmaster

--- a/salt/os/chrony.sls
+++ b/salt/os/chrony.sls
@@ -1,0 +1,19 @@
+# Chrony
+# ======
+# Manage `chrony` through Salt.
+#
+# This is a wrapper around 'saltstack-formulas/chrony-formula', which needs to
+# be pulled by salt master first before it can be referenced.
+
+
+{% if salt['state.sls_exists']("chrony") %}
+include:
+  - chrony
+{% else %}
+warn-formula-not-pulled:
+  test.configurable_test_state:
+    - result: True
+    - warnings: >
+        chrony-formula is not pulled in yet. Make sure GitFS is properly set
+        up, then restart the salt master.
+{% endif %}

--- a/salt/salt/files/master
+++ b/salt/salt/files/master
@@ -1,5 +1,9 @@
 # salt-master Global Configuration
 # This file should normally be installed at: /etc/salt/master
 
+# By default, we assume "saltmaster" is the unprivileged user running salt master.
+# See docs.saltproject.io/en/latest/ref/configuration/nonroot.html
 user: saltmaster
+
+# Use GPG-renderer by default for sensitive and encrypted data
 renderer: jinja | yaml | gpg

--- a/salt/salt/files/master.d/formulas.conf
+++ b/salt/salt/files/master.d/formulas.conf
@@ -1,0 +1,15 @@
+# Configs for pulling in formulas from external sources
+# =====================================================
+# This file should normally be installed at: /etc/salt/master.d/formulas.conf
+
+
+fileserver_backend:
+  - roots
+  - gitfs
+
+
+gitfs_provider: pygit2
+
+
+gitfs_remotes:
+  - https://github.com/ryhino/chrony-formula  # Manage Chrony

--- a/salt/salt/formulas.sls
+++ b/salt/salt/formulas.sls
@@ -1,0 +1,20 @@
+# Formulas
+# ========
+# Salt states that can be pulled in from external sources, usually GitHub.
+
+
+# Install pygit2, required for GitFS to pull stuff from Git repos.
+pygit2:
+  pip.installed:
+    - upgrade: true
+
+
+# Copy over formulas.conf for actual configs
+/etc/salt/master.d/formulas.conf:
+  file.managed:
+    - source: salt://salt/files/master.d/formulas.conf
+    - user: saltmaster
+    - group: saltmaster
+    - mode: 644
+    - require:
+        - file: /etc/salt/master.d

--- a/salt/salt/master.sls
+++ b/salt/salt/master.sls
@@ -2,6 +2,11 @@
 # ===========================
 # These states should result in a usable Salt Master for deploying under Ryhino.
 
+
+include:
+  - salt.formulas
+
+
 /etc/salt/master:
   file.managed:
     - source: salt://salt/files/master
@@ -11,9 +16,19 @@
     - makedirs: True
 
 
+# This directory should be created by Salt automatically, but just in case.
+/etc/salt/master.d:
+  file.directory:
+    - user: saltmaster
+    - group: saltmaster
+    - dir_mode: 755
+    - file_mode: 644
+
+
 # Open salt-master ports to public
 {% if grains['os'] == 'Rocky' %}
 public:
   firewalld.present:
-    - services: salt-master
+    - services:
+        - salt-master
 {% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,6 +1,9 @@
 # Highstate for all Salt minions under Ryhino
 
 base:
+  '*':
+    - os.chrony
+
   'salt.*':
     - os.auto-update
     - salt.master


### PR DESCRIPTION
- Add support GitFS to salt master, so it can pull in salt formulas
- Add "chrony-formula" to manage Chrony, which is currently used to sync with the internal NTP server hosted on pfSesne.

## Logs
#### 1st Run
```
[saltmaster@salt srv]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: chrony-package-install-pkg-installed
    Function: pkg.installed
        Name: chrony
      Result: True
     Comment: All specified packages are already installed
     Started: 19:50:29.334727
    Duration: 702.982 ms
     Changes:
----------
          ID: chrony-config-file-file-managed
    Function: file.managed
        Name: /etc/chrony.conf
      Result: True
     Comment: File /etc/chrony.conf updated
     Started: 19:50:30.090903
    Duration: 86.434 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -3,16 +3,7 @@
                   # Your changes will be overwritten.
                   ########################################################################

                  -server 0.centos.pool.ntp.org iburst
                  -
                  -
                  -server 1.centos.pool.ntp.org iburst
                  -
                  -
                  -server 2.centos.pool.ntp.org iburst
                  -
                  -
                  -server 3.centos.pool.ntp.org iburst
                  +server pfsense.bedrock.ryanl.io iburst



----------
          ID: chrony-service-running-service-running
    Function: service.running
        Name: chronyd
      Result: True
     Comment: Service restarted
     Started: 19:50:30.350488
    Duration: 349.106 ms
     Changes:
              ----------
              chronyd:
                  True
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 19:50:30.700857
    Duration: 49.119 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 19:50:30.769567
    Duration: 43.625 ms
     Changes:
----------
          ID: pygit2
    Function: pip.installed
      Result: True
     Comment: Python package pygit2 was already installed
              All specified packages are already installed and up-to-date
     Started: 19:50:30.850367
    Duration: 5723.476 ms
     Changes:
----------
          ID: /etc/salt/master.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/master.d is in the correct state
     Started: 19:50:36.575719
    Duration: 3.899 ms
     Changes:
----------
          ID: /etc/salt/master.d/formulas.conf
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master.d/formulas.conf is in the correct state
     Started: 19:50:36.580089
    Duration: 31.479 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 19:50:36.611909
    Duration: 27.81 ms
     Changes:
----------
          ID: public
    Function: firewalld.present
      Result: True
     Comment: 'public' is already in the desired state.
     Started: 19:50:36.654751
    Duration: 2604.919 ms
     Changes:
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 19:50:39.261020
    Duration: 52.532 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.profiles.d is in the correct state
     Started: 19:50:39.314115
    Duration: 113.481 ms
     Changes:
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 19:50:39.428150
    Duration: 114.556 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 19:50:39.543282
    Duration: 4.955 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 19:50:39.548818
    Duration: 9.45 ms
     Changes:

Summary for salt.bedrock.ryanl.io
-------------
Succeeded: 15 (changed=2)
Failed:     0
-------------
Total states run:     15
Total run time:    9.918 s
```

#### 2rd Run
```
[saltmaster@salt ~]$ salt 'salt*' state.apply
salt.bedrock.ryanl.io:
----------
          ID: chrony-package-install-pkg-installed
    Function: pkg.installed
        Name: chrony
      Result: True
     Comment: All specified packages are already installed
     Started: 19:54:40.022970
    Duration: 705.674 ms
     Changes:
----------
          ID: chrony-config-file-file-managed
    Function: file.managed
        Name: /etc/chrony.conf
      Result: True
     Comment: File /etc/chrony.conf is in the correct state
     Started: 19:54:40.781117
    Duration: 58.113 ms
     Changes:
----------
          ID: chrony-service-running-service-running
    Function: service.running
        Name: chronyd
      Result: True
     Comment: The service chronyd is already running
     Started: 19:54:40.847053
    Duration: 97.986 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: file.managed
      Result: True
     Comment: File /root/salt/scripts/os/dnf-upgrade-and-reboot.sh is in the correct state
     Started: 19:54:40.945659
    Duration: 19.445 ms
     Changes:
----------
          ID: /root/salt/scripts/os/dnf-upgrade-and-reboot.sh
    Function: cron.present
      Result: True
     Comment: Cron /root/salt/scripts/os/dnf-upgrade-and-reboot.sh already present
     Started: 19:54:40.972920
    Duration: 19.544 ms
     Changes:
----------
          ID: pygit2
    Function: pip.installed
      Result: True
     Comment: Python package pygit2 was already installed
              All specified packages are already installed and up-to-date
     Started: 19:54:41.007854
    Duration: 5233.419 ms
     Changes:
----------
          ID: /etc/salt/master.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/master.d is in the correct state
     Started: 19:54:46.242415
    Duration: 2.515 ms
     Changes:
----------
          ID: /etc/salt/master.d/formulas.conf
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master.d/formulas.conf is in the correct state
     Started: 19:54:46.245244
    Duration: 19.155 ms
     Changes:
----------
          ID: /etc/salt/master
    Function: file.managed
      Result: True
     Comment: File /etc/salt/master is in the correct state
     Started: 19:54:46.264664
    Duration: 16.301 ms
     Changes:
----------
          ID: public
    Function: firewalld.present
      Result: True
     Comment: 'public' is already in the desired state.
     Started: 19:54:46.290481
    Duration: 1532.555 ms
     Changes:
----------
          ID: /etc/salt/cloud
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud is in the correct state
     Started: 19:54:47.824256
    Duration: 44.78 ms
     Changes:
----------
          ID: /etc/salt/cloud.profiles.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.profiles.d is in the correct state
     Started: 19:54:47.869624
    Duration: 95.277 ms
     Changes:
----------
          ID: /etc/salt/cloud.providers.d
    Function: file.recurse
      Result: True
     Comment: The directory /etc/salt/cloud.providers.d is in the correct state
     Started: 19:54:47.965424
    Duration: 97.35 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d
    Function: file.directory
      Result: True
     Comment: The directory /etc/salt/cloud.initial-keys.d is in the correct state
     Started: 19:54:48.063294
    Duration: 4.591 ms
     Changes:
----------
          ID: /etc/salt/cloud.initial-keys.d/generic-rocky-9.1
    Function: file.managed
      Result: True
     Comment: File /etc/salt/cloud.initial-keys.d/generic-rocky-9.1 is in the correct state
     Started: 19:54:48.068354
    Duration: 8.841 ms
     Changes:

Summary for salt.bedrock.ryanl.io
-------------
Succeeded: 15
Failed:     0
-------------
Total states run:     15
Total run time:    7.956 s
```