### PR TITLE
(RH-21) Pull in `salt-bootstrap` through submodule; Use dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "salt/salt/files/salt-bootstrap"]
+	path = salt/salt/files/salt-bootstrap
+	url = git@github.com:saltstack/salt-bootstrap

--- a/salt/salt/cloud.sls
+++ b/salt/salt/cloud.sls
@@ -10,7 +10,7 @@ pyvmomi:
   pip.installed:
     - upgrade: true
 
-
+# Global salt-cloud config file
 /etc/salt/cloud:
   file.managed:
     - source: salt://salt/files/cloud
@@ -20,6 +20,7 @@ pyvmomi:
     - makedirs: True
 
 
+# VM profiles, such as "generic-ubuntu-18.04"
 /etc/salt/cloud.profiles.d:
   file.recurse:
     - source: salt://salt/files/cloud.profiles.d
@@ -30,6 +31,7 @@ pyvmomi:
     - template: jinja
 
 
+# Provision providers, such as vCenters
 /etc/salt/cloud.providers.d:
   file.recurse:
     - source: salt://salt/files/cloud.providers.d
@@ -39,10 +41,11 @@ pyvmomi:
     - file_mode: 644
     - template: jinja
 
-# Keys to log into VMs deployed by `salt-cloud` after they get cloned/created
-# initially.
+
+# Keys to log into VMs deployed by `salt-cloud` after they get cloned/created initially.
 # Each VM template will have a different SSH key that can be used to log into
 # `root`, which is to facilitate Salt doing some initial bootstrapping.
+# These keys will be copied to all salt masters and defined under "initial_keys.map".
 /etc/salt/cloud.initial-keys.d:
   file.directory:
     - user: saltmaster
@@ -50,8 +53,6 @@ pyvmomi:
     - dir_mode: 755
     - file_mode: 644
 
-
-# These keys will be copied to all salt masters and are defined under "initial_keys.map".
 {% for key_name in initial_keys %}
 /etc/salt/cloud.initial-keys.d/{{ key_name }}:
   file.managed:
@@ -60,3 +61,13 @@ pyvmomi:
     - mode: 600
     - contents: {{ initial_keys[key_name] | yaml_encode }}
 {% endfor %}
+
+
+# Use a dev version of "bootstrap-salt.sh" to side step some issues with deploying
+# newer versions of OS.
+/etc/salt/cloud.deploy.d/bootstrap-salt.sh:
+  file.managed:
+    - source: salt://salt/files/salt-bootstrap/bootstrap-salt.sh
+    - user: saltmaster
+    - group: saltmaster
+    - mode: 744

--- a/salt/salt/files/cloud.profiles.d/infra-rocky-obsidian.conf
+++ b/salt/salt/files/cloud.profiles.d/infra-rocky-obsidian.conf
@@ -38,6 +38,7 @@ infra-rocky-obsidian:
 
   power_on: True
   deploy: True
+  script_args: onedir  # Remove after salt/salt-bootstrap#1890
   customization: True
   minion:
     master: salt.bedrock.ryanl.io


### PR DESCRIPTION
At the time of writing (2023/02/02), the bootstrap-salt.sh script is still stuck at v2022.10.04, which has some compatibility issues with Rock Linux 9.

So, the solution in this PR is to just pull in development branch of `salt-bootstrap` and copy the deploy script to salt masters through the typical `file.managed` state. This way, we also get version pinning for free, since submodule relies on commit hashes.